### PR TITLE
Release v2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.1.2] - 2026-04-17
+
+### Changed
+
+- Updated OpenTelemetry dependencies: SDK 2.6.0 → 2.6.1, exporters/logs 0.213.0 → 0.214.0
+- Bumped `@opentelemetry/api` peer dependency range to `^1.9.1`
+
 ## [2.1.1] - 2026-03-06
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invinite/otel-web",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "type": "module",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Patch release bundling OpenTelemetry dependency updates since v2.1.1.

- OTel SDK `2.6.0 → 2.6.1` (resources, sdk-trace-base, sdk-trace-web)
- OTel exporters/logs `0.213.0 → 0.214.0` (exporter-logs-otlp-http, exporter-trace-otlp-http, sdk-logs)
- Peer dep `@opentelemetry/api` range bumped to `^1.9.1`

Dev-only bumps (typescript 5→6, eslint-config 1→2, playwright, vitest) are already on main and not called out in the changelog.

## Test plan

- [x] CI green
- [x] After merge, tag `v2.1.2` on main to trigger npm publish