### PR TITLE
chore: bump yarn 4.12.0 -> 4.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,5 +80,5 @@
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"
   },
-  "packageManager": "yarn@4.12.0"
+  "packageManager": "yarn@4.18.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 10
   cacheKey: 10c0
 
 "@blazediff/core@npm:1.9.1":


### PR DESCRIPTION
Bumps the Corepack-pinned Yarn from 4.12.0 to 4.18.0 (latest). Lockfile metadata migrates v8 → v10.

## Hardened defaults

Yarn 4.17+ added supply-chain protections that are **on by default**. Running `yarn install` after the bump offers to write explicit opt-outs into `.yarnrc.yml` to preserve old behaviour — this PR deliberately does **not** take them:

| Setting | 4.12 behaviour | 4.18 default (adopted here) |
| --- | --- | --- |
| `enableScripts` | `true` | `false` — no package install scripts |
| `approvedGitRepositories` | `**` | `[]` — no git dependencies |
| `npmMinimalAgeGate` | `0` | `1440` — refuse versions published <24h ago |

Verified locally on the hardened defaults after a clean `rm -rf node_modules` install: `yarn format`, `yarn lint`, `yarn build` and `yarn test` (32/32) all pass. The project has no install scripts and no git dependencies, so nothing relies on the loosened settings.

## Note for dependabot

`npmMinimalAgeGate: 1440` means a dependabot PR opened within 24h of a release can fail `yarn install` until the version ages past the gate; a re-run once it does will pass. Worth watching — if it proves noisy we can lower the gate rather than disable it.