### PR TITLE
test: fix flaky document-load SSR trace context test

### DIFF
--- a/tests/plugins/document-load.test.ts
+++ b/tests/plugins/document-load.test.ts
@@ -43,10 +43,13 @@ describe("createDocumentLoadPlugin", () => {
   describe("SSR trace context", () => {
     const TEST_TRACE_ID = "0af7651916cd43dd8448eb211c80319c";
     const TEST_SPAN_ID = "b7ad6b7169203331";
-    let teardown: () => void;
+    // Reassigned to a no-op once called, so the test can tear down early to
+    // flush spans without afterEach shutting the same provider down twice.
+    let teardown = () => {};
 
     afterEach(() => {
       teardown();
+      teardown = () => {};
       document
         .querySelectorAll('meta[name="traceparent"], meta[name="tracestate"]')
         .forEach((el) => el.remove());
@@ -63,6 +66,15 @@ describe("createDocumentLoadPlugin", () => {
         serviceName: "test-ssr-propagation",
         plugins: [createDocumentLoadPlugin()],
       });
+
+      // The plugin emits document.load synchronously during setup (readyState is
+      // already "complete" here), but initialize() wires a BatchSpanProcessor
+      // whose default 5s flush interval is exactly waitForSpans' default
+      // timeout — waiting on that timer was a coin flip. Tearing down shuts the
+      // provider down, which force-flushes, matching how the rest of the suite
+      // flushes explicitly before asserting on collected spans.
+      teardown();
+      teardown = () => {};
 
       const spans = await waitForSpans((s) =>
         s.some((sp) => sp.name === "document.load"),


### PR DESCRIPTION
`document-load.test.ts > SSR trace context > inherits traceId from <meta name='traceparent'>` fails intermittently — it took down CI on #39, and reproduces locally under load.

## Cause

The test asserts on a span collected by the test collector, but relies on `initialize()`'s `BatchSpanProcessor` to export it. That processor uses OpenTelemetry's default `scheduledDelayMillis` of **5000ms** — and `waitForSpans` defaults to a **5000ms** timeout. The export fired exactly as the poll loop gave up, so passing was a coin flip. The failing runs are all ~5150ms with `expected undefined to be defined`.

The rest of the suite doesn't have this problem because it flushes explicitly before asserting (`tp.flush()`, `processor.forceFlush()`). This test was the only one asserting on an exported span while waiting on the batch timer. The other `initialize()`-based tests (fetch `propagateToUrls`) assert on request headers, not collected spans, so they're unaffected.

## Fix

The plugin emits `document.load` synchronously during `setup()` (`document.readyState` is already `"complete"` in the browser test), so the span is queued by the time `initialize()` returns. Calling the teardown function shuts the provider down, which force-flushes — deterministic instead of timer-dependent, and consistent with the rest of the suite.

`teardown` is reassigned to a no-op after being called so `afterEach` doesn't shut the same provider down twice, and now defaults to a no-op so a throw before `initialize()` doesn't turn into a confusing `afterEach` error.

## Result

| | before | after |
| --- | --- | --- |
| SSR test | ~5151ms (flaky) | ~53ms |
| full suite | ~9.5s | ~2.7s |

Verified: the test 6/6 green in isolation, full suite 32/32 twice, plus `format`/`lint`/`build`. No production code touched.