### PR TITLE
release: v2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.1.3] - 2026-08-03
+
+### Changed
+
+- Updated OpenTelemetry dependencies: SDK 2.6.1 → 2.10.0, exporters/logs 0.214.0 → 0.221.0, semantic conventions 1.40.0 → 1.43.0
+- Provider: adapted to `BatchLogRecordProcessor` options-object constructor introduced in `@opentelemetry/sdk-logs` 0.221.0
+
 ## [2.1.2] - 2026-04-17
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invinite/otel-web",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "type": "module",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Patch release. Version bump + changelog entry only — no source changes (the code change this release carries, the `BatchLogRecordProcessor` adaptation, already landed in #37).

```
## [2.1.3] - 2026-08-03

### Changed

- Updated OpenTelemetry dependencies: SDK 2.6.1 → 2.10.0, exporters/logs 0.214.0 → 0.221.0, semantic conventions 1.40.0 → 1.43.0
- Provider: adapted to `BatchLogRecordProcessor` options-object constructor introduced in `@opentelemetry/sdk-logs` 0.221.0
```

## Why patch

No public API of the library changed. The `provider.ts` change is internal — it adapts to a constructor signature change in `@opentelemetry/sdk-logs`. Consumers' `initialize()` config and all plugin APIs are unchanged.

Note the raised dependency floor: `@opentelemetry/sdk-logs` is now `^0.221.0`, so consumers resolving an older 0.x will get the new one. That's enforced by the range rather than left to chance — 2.1.3 would not work against 0.219.

## Not in the changelog

`main` also picked up toolchain-only work since 2.1.2 that consumers can't observe, so it's deliberately omitted: Yarn 4.12 → 4.18 (#38), dropping corepack for a vendored Yarn (#39), and a flaky-test fix (#40).

## Verification

Full sequence on the rebased branch: `yarn install`, `yarn format`, `yarn lint`, `yarn build`, `yarn test` (32/32). `yarn pack --dry-run` ships `dist/` + `package.json` only.

After merge, tag `v2.1.3` on the merge commit to trigger `publish.yaml`. That tag push is the step that publishes to npm.