### PR TITLE
ci: pin actions by SHA, let dependabot update them

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -12,3 +12,18 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  # Actions are pinned by commit SHA; dependabot bumps the SHA and the trailing
+  # `# vX.Y.Z` comment together, so pinning doesn't mean going stale.
+  #
+  # These PRs need merging by hand: the Automerge workflow deliberately skips
+  # `dependabot/github_actions` branches, because GITHUB_TOKEN has no `workflows`
+  # scope and so cannot merge a change to .github/workflows/*.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Only `default-days` is honoured for this ecosystem — the semver-* cooldown
+    # keys silently break parsing here.
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "lts/*"
       - uses: ./.github/actions/setup-yarn

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,12 +15,12 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Verify tag is on main
         run: git merge-base --is-ancestor ${{ github.sha }} origin/main
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "lts/*"
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
Follows glowbox's setup: SHA-pinned actions plus a dependabot `github-actions` ecosystem so the pins don't go stale.

## Pinning

`actions/checkout@v4` is a *mutable* reference — a tag can be repointed, so whoever controls it controls what executes in CI. That matters most in `publish.yaml`, which runs with `id-token: write` and publishes to npm with provenance. A commit SHA can't be repointed.

| action | was | now |
| --- | --- | --- |
| `actions/checkout` | `@v4` | `@3d3c42e…` `# v7.0.1` |
| `actions/setup-node` | `@v4` | `@820762…` `# v7.0.0` |

Both SHAs were resolved from each repo's latest release via the API and verified in both directions (tag → SHA and SHA → tag), rather than copied. They match what glowbox pins, independently arrived at.

The local `./.github/actions/setup-yarn` stays a path reference — it's in-repo, so there's nothing to pin.

## v4 → v7

This also clears the `Node.js 20 is deprecated` warnings the runner emits today. I checked the v5/v6/v7 release notes for anything touching the inputs used here (`fetch-depth`, `node-version`, `registry-url`) and found nothing: the majors are runner/Node-runtime bumps, plus a v7 change blocking fork-PR checkout for `pull_request_target` and `workflow_run` — neither trigger is used in this repo.

## Dependabot

New `github-actions` ecosystem, weekly, with a 7-day cooldown. Dependabot understands SHA pins and rewrites the SHA *and* the trailing `# vX.Y.Z` comment together, so pinning doesn't mean going stale.

Only `cooldown.default-days` is honoured for this ecosystem — the `semver-*` keys silently break parsing — so only that one is set. Noted in a comment.

These PRs will need merging by hand, which is pre-existing and deliberate: the Automerge workflow skips `dependabot/github_actions` branches because `GITHUB_TOKEN` lacks the `workflows` scope and can't merge changes under `.github/workflows/`.

## Verification

All five workflow/action YAML files parse, and no unpinned external `uses:` remain. CI on this PR exercises the new `checkout`/`setup-node` pins directly; as before, `publish.yaml` only runs on a `v*` tag, so its identical swap is first exercised on the next release.