### PR TITLE
chore: ignore typescript 7.0.x in dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,6 +4,20 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # TypeScript 7.0 (the native port) ships no programmatic API, so
+      # typescript-eslint cannot run against it at all — every released version
+      # through 8.66.0 caps typescript at <6.1.0, and `yarn lint` dies while
+      # ESLint loads its config. Upstream is blocked on TypeScript, not behind:
+      # https://github.com/typescript-eslint/typescript-eslint/issues/10940
+      #
+      # TS 7.1 is expected to ship a new API, so only the 7.0.x line is ignored —
+      # 7.1.0+ still comes through, which is when this is worth retrying.
+      #
+      # Must be `7.0.x`, not `^7.0.0`: GitHub's docs suggest the caret form, but in
+      # npm semver `^7.0.0` means >=7.0.0 <8.0.0 and would silently swallow 7.1 too.
+      - dependency-name: "typescript"
+        versions: ["7.0.x"]
     groups:
       opentelemetry:
         patterns:


### PR DESCRIPTION
Stops #44 and its weekly re-proposals, without also blocking TypeScript 7.1 — the release where this becomes viable again.

## Why 7.0 can't be taken

TypeScript 7.0 is the native (Go) port, and its `typescript` package no longer exports the compiler API at the root. `import "typescript"` yields only `{default, module.exports, version, versionMajorMinor}` — no `createProgram`, no `SyntaxKind`. It's a version stub.

typescript-eslint is built on that API, so it fails dereferencing it (`Cannot read properties of undefined (reading 'Cjs')`), which surfaces as a misleading `ERR_INTERNAL_ASSERTION` from Node's ESM/CJS translator while ESLint dynamically imports `eslint.config.js`. That's the #44 CI failure. Reproduced on both CI (Node lts/*) and locally (Node 26).

This isn't a version-range formality: **every** released typescript-eslint — 8.61.0 through latest 8.66.0, plus `canary` — declares `peerDependencies.typescript: ">=4.8.4 <6.1.0"`. Yarn already warns (`YN0060`). Upstream labelled [#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940) *"blocked by external API"* and said plainly there is nothing they can do without a stable JS API. Microsoft's TS 7.0 announcement confirms 7.0 ships no API and expects **7.1** to.

Note this is a *linter* block, not a code-compatibility one: TS 7 typechecks this repo cleanly (`tsc --noEmit`, exit 0) and emits declarations correctly. The eventual migration should be uneventful.

## The ignore

```yaml
- dependency-name: "typescript"
  versions: ["7.0.x"]
```

Deliberately **not** `^7.0.0`. GitHub's docs suggest the caret form for npm, but npm reads `^7.0.0` as `>=7.0.0 <8.0.0`, which would silently swallow 7.1 too — the opposite of the intent. Verified rather than assumed:

```
$ npx semver -r "7.0.x"  7.0.2 7.0.9 7.1.0 7.1.5 8.0.0
7.0.2
7.0.9
$ npx semver -r "^7.0.0" 7.0.2 7.1.0
7.0.2
7.1.0     # <- would have blocked 7.1
```

## Considered and rejected

- **Side-by-side TS 6/7** (Microsoft's sanctioned workaround: alias `typescript` → `npm:@typescript/typescript6`, TS 7 under a second alias). Works, but ~50MB of native binaries and two `tsc` binaries to speed up typechecking a 10-file library.
- **Swapping typescript-eslint for oxlint** — needs no `typescript` package, type-aware mode stable on tsgo, and this repo uses only syntactic rules (`tseslint.configs.recommended`), so it's realistic. But those rules come from the shared `@invinite/eslint-config`, so that decision belongs there, not in one consumer repo.

Both remain open for when 7.1 lands.

## Verification

Config parses; `ignore` sits at the npm ecosystem level with `groups` and the `github-actions` entry untouched. On TS 6: `yarn install` warning-free, `lint`/`format`/`build` clean, tests 32/32.

Dependabot's own config validation only runs server-side — I'll confirm the config is accepted and no new 7.0.x PR appears after merge.